### PR TITLE
Remove buggy & obsolete slash handling code.

### DIFF
--- a/helpers/utils.js
+++ b/helpers/utils.js
@@ -4,7 +4,7 @@ const { isString } = require("./stringManipulation");
 const settingsCue = "x:";
 
 let areDebugging = false;
-let dontLogToConsole = false;
+let dontLogToConsole = true;
 let logAllToFile = false;
 
 function csvToLiteral(csv) {

--- a/index.js
+++ b/index.js
@@ -171,49 +171,56 @@ var actionTypes = {
 };
 
 if (require.main === module) {
-    // First two arguments for a node process are always "Node"
-    // and the path to this app. Trash those.
-    const myArgs = process.argv.slice(2);
-    utils.debugLog("myArgs: ", myArgs);
+    try {
+        // First two arguments for a node process are always "Node"
+        // and the path to this app. Trash those.
+        const myArgs = process.argv.slice(2);
+        utils.debugLog("myArgs: ", myArgs);
 
-    var command =
-        myArgs.indexOf("/openInBrowser") > -1
-            ? actionTypes.OPEN_IN_BROWSER
-            : myArgs.indexOf("/coverage") > -1
-            ? actionTypes.WITH_COVERAGE
-            : myArgs.indexOf("/findAllSuites") > -1
-            ? actionTypes.FIND_ALL_CHUTZPAHS
-            : myArgs.indexOf("/runAllSuites") > -1
-            ? actionTypes.RUN_ALL_CHUTZPAHS
-            : myArgs.indexOf("/walkAllRunOne") > -1
-            ? actionTypes.WALK_ALL_RUN_ONE
-            : myArgs.indexOf("/runOne") > -1
-            ? actionTypes.RUN_ONE_IN_KARMA
-            : actionTypes.PRINT_USAGE;
+        var command =
+            myArgs.indexOf("/openInBrowser") > -1
+                ? actionTypes.OPEN_IN_BROWSER
+                : myArgs.indexOf("/coverage") > -1
+                ? actionTypes.WITH_COVERAGE
+                : myArgs.indexOf("/findAllSuites") > -1
+                ? actionTypes.FIND_ALL_CHUTZPAHS
+                : myArgs.indexOf("/runAllSuites") > -1
+                ? actionTypes.RUN_ALL_CHUTZPAHS
+                : myArgs.indexOf("/walkAllRunOne") > -1
+                ? actionTypes.WALK_ALL_RUN_ONE
+                : myArgs.indexOf("/runOne") > -1
+                ? actionTypes.RUN_ONE_IN_KARMA
+                : actionTypes.PRINT_USAGE;
 
-    var filePath = myArgs.shift();
-    utils.debugLog(command);
-    if (command !== actionTypes.PRINT_USAGE && !fs.existsSync(filePath)) {
-        throw `Invalid starting file ${filePath}`;
-    }
-
-    var expressPort = 3000;
-    cmdCallHandler(filePath, expressPort, command).then(function (resultsIfAny) {
-        utils.debugLog("done");
-
-        if (Array.isArray(resultsIfAny) && !resultsIfAny.every((x) => x === undefined)) {
-            utils.debugLog("::RESULTS::");
-            utils.debugLog(resultsIfAny);
-            utils.debugLog("::eoRESULTS::");
-
-            const firstError = resultsIfAny.find((x) => x && x !== 0);
-
-            // On Windows, to see the returned code (https://stackoverflow.com/a/334893/1028230):
-            // cmd.exe: echo %ERRORLEVEL%
-            // pwsh.exe: echo $LastExitCode
-            process.exit(firstError || 0);
+        var filePath = myArgs.shift();
+        utils.debugLog(command);
+        if (command !== actionTypes.PRINT_USAGE && !fs.existsSync(filePath)) {
+            throw `Invalid starting file ${filePath}`;
         }
-    });
+
+        var expressPort = 3000;
+        cmdCallHandler(filePath, expressPort, command).then(function (resultsIfAny) {
+            utils.debugLog("done");
+
+            if (
+                Array.isArray(resultsIfAny) &&
+                !resultsIfAny.every((x) => x === undefined)
+            ) {
+                utils.debugLog("::RESULTS::");
+                utils.debugLog(resultsIfAny);
+                utils.debugLog("::eoRESULTS::");
+
+                const firstError = resultsIfAny.find((x) => x && x !== 0);
+
+                // On Windows, to see the returned code (https://stackoverflow.com/a/334893/1028230):
+                // cmd.exe: echo %ERRORLEVEL%
+                // pwsh.exe: echo $LastExitCode
+                process.exit(firstError || 0);
+            }
+        });
+    } catch (e) {
+        console.error("An error occurred:", e);
+    }
 }
 
 module.exports = cmdCallHandler;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "khutzpa",
-    "version": "0.0.1-alpha.6",
+    "version": "0.0.1-alpha.7",
     "description": "Node powered, cross-platform, drop-in replacement for Chutzpah.exe",
     "main": "index.js",
     "bin": "index.js",

--- a/services/chutzpahReader.js
+++ b/services/chutzpahReader.js
@@ -49,10 +49,12 @@ function minimatchEngine(selector, fullPaths, home, selectorName) {
         // Then remember which paths were doctored and restore them after.
         var withSlashes = [];
         var noSlashesForComparison = [];
-        if (!manip.startsWithSlash(includePattern)) {
-            withSlashes = fullPaths.filter((x) => manip.startsWithSlash(x));
-            noSlashesForComparison = manip.removeLeadingSlashes(withSlashes);
-        }
+
+        // ????: Is this necessary now after standardizing on full paths?
+        // if (!manip.startsWithSlash(includePattern)) {
+        //     withSlashes = fullPaths.filter((x) => manip.startsWithSlash(x));
+        //     noSlashesForComparison = manip.removeLeadingSlashes(withSlashes);
+        // }
 
         var matches = fullPaths.filter((singleFullPath) =>
             hasRelativeOrFullPathMatch(singleFullPath, home, includePattern)

--- a/services/chutzpahReader.js
+++ b/services/chutzpahReader.js
@@ -15,7 +15,8 @@ utils.debugLog("isWindows? " + isWindows);
 // We have two competing issues here...
 // A. *.js style globs only match files in the root dir.
 // B. minimatch always fails to match ../s in paths.
-//      https://github.com/isaacs/minimatch/issues/30#issuecomment-1040599045
+//      Treatise on glob "standards":
+//          https://github.com/isaacs/minimatch/issues/30#issuecomment-1040599045
 //      (It looked like optimizationLevel:2 would change that, but it doesn't.)
 //      (Appears that's b/c you're using v5, not v7+)
 //      https://github.com/isaacs/minimatch/blob/main/changelog.md
@@ -39,6 +40,7 @@ function minimatchEngine(selector, fullPaths, home, selectorName) {
     // "Includes all tests that contain test1 in its path. This is in glob format."
     //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     // If that's accurate, that's not how globs work *in the minimatch package*.
+    // (See excellent treatise on glob "standards", above.)
     //
     // Recall that minimatch really wants you to use full paths.
     // See: `partial` option in minimatch, eg:

--- a/services/chutzpahReader.js
+++ b/services/chutzpahReader.js
@@ -5,7 +5,6 @@ const minimatch = require("minimatch");
 const nodePath = require("node:path");
 const Os = require("os");
 const fileSystemService = require("./fileSystemService");
-const manip = require("../helpers/stringManipulation");
 const utils = require("../helpers/utils");
 
 // const { config } = require("process");
@@ -39,42 +38,17 @@ function minimatchEngine(selector, fullPaths, home, selectorName) {
     // { "Includes": ["*test1*"] },
     // "Includes all tests that contain test1 in its path. This is in glob format."
     //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    // If that's accurate, that's not how globs in minimatch work.
+    // If that's accurate, that's not how globs work *in the minimatch package*.
     //
-    // Below: Trying to solve the minimatch starting slash issue.
+    // Recall that minimatch really wants you to use full paths.
+    // See: `partial` option in minimatch, eg:
+    // https://github.com/isaacs/minimatch#partial
+    // "This is useful in applications where you're walking through a folder structure, and don't yet have the full path..."
+    // This means that if we stop using full paths, you'll need to revisit starting slash usage.
     selector[selectorName].forEach(function (includePattern) {
-        // if the pattern doesn't have a leading slash but our files do,
-        // that's an issue, since that seems to mean "root of *relative*
-        // path to Chutzpah instead of root of file system to minimatch.
-        // Then remember which paths were doctored and restore them after.
-        var withSlashes = [];
-        var noSlashesForComparison = [];
-
-        // ????: Is this necessary now after standardizing on full paths?
-        // if (!manip.startsWithSlash(includePattern)) {
-        //     withSlashes = fullPaths.filter((x) => manip.startsWithSlash(x));
-        //     noSlashesForComparison = manip.removeLeadingSlashes(withSlashes);
-        // }
-
         var matches = fullPaths.filter((singleFullPath) =>
             hasRelativeOrFullPathMatch(singleFullPath, home, includePattern)
         );
-
-        // Ok, if we stripped a leading slash, put it back. Inefficient, but computers
-        // love doing this stuff. Right?
-        matches = matches.map((x) => {
-            var index = noSlashesForComparison.indexOf(x);
-            // Yes, there are side effects. Yes, that's smelly, but also gets us around
-            // the "what if I have `spam.txt` AND `/spam.txt` issue?
-            if (index > -1) {
-                var ret = withSlashes[index];
-                noSlashesForComparison.splice(index, 1);
-                withSlashes.splice(index, 1);
-                return ret;
-            }
-
-            return x;
-        });
 
         // I feel like this dedupe is a painfully inefficient operation.
         allMatches = allMatches.concat(

--- a/services/coverage.js
+++ b/services/coverage.js
@@ -16,19 +16,20 @@ function startKarma(overrides) {
 
     var serverHasStarted = false;
 
-    karmaConfig.files.forEach((x, i) => {
-        if (stringManipulation.startsWithSlash(x)) {
-            karmaConfig.files[i] = x.substring(1);
-        }
-    });
+    // ????: Is this slash removal necessary?
+    // karmaConfig.files.forEach((x, i) => {
+    //     if (stringManipulation.startsWithSlash(x)) {
+    //         karmaConfig.files[i] = x.substring(1);
+    //     }
+    // });
 
-    var processorKeys = Object.keys(karmaConfig.preprocessors);
-    processorKeys.forEach((key) => {
-        if (stringManipulation.startsWithSlash(key)) {
-            karmaConfig.preprocessors[key.substring(1)] = ["coverage"];
-            delete karmaConfig.preprocessors[key];
-        }
-    });
+    // var processorKeys = Object.keys(karmaConfig.preprocessors);
+    // processorKeys.forEach((key) => {
+    //     if (stringManipulation.startsWithSlash(key)) {
+    //         karmaConfig.preprocessors[key.substring(1)] = ["coverage"];
+    //         delete karmaConfig.preprocessors[key];
+    //     }
+    // });
     utils.debugLog(karmaConfig);
 
     return karma.config

--- a/services/coverage.js
+++ b/services/coverage.js
@@ -6,7 +6,6 @@ const opener = require("opener");
 
 const karmaConfigTools = require("./karmaConfigTools");
 const expressServer = require("./expressServer");
-const stringManipulation = require("../helpers/stringManipulation");
 const utils = require("../helpers/utils");
 
 function startKarma(overrides) {
@@ -15,22 +14,6 @@ function startKarma(overrides) {
     utils.debugLog(karmaConfig);
 
     var serverHasStarted = false;
-
-    // ????: Is this slash removal necessary?
-    // karmaConfig.files.forEach((x, i) => {
-    //     if (stringManipulation.startsWithSlash(x)) {
-    //         karmaConfig.files[i] = x.substring(1);
-    //     }
-    // });
-
-    // var processorKeys = Object.keys(karmaConfig.preprocessors);
-    // processorKeys.forEach((key) => {
-    //     if (stringManipulation.startsWithSlash(key)) {
-    //         karmaConfig.preprocessors[key.substring(1)] = ["coverage"];
-    //         delete karmaConfig.preprocessors[key];
-    //     }
-    // });
-    utils.debugLog(karmaConfig);
 
     return karma.config
         .parseConfig(

--- a/services/wrappedKarma.js
+++ b/services/wrappedKarma.js
@@ -20,25 +20,26 @@ function startKarma(karmaRunId, overrides) {
         );
         var karmaConfig = karmaConfigTools.createKarmaConfig(overrides);
 
-        karmaConfig.files.forEach((x, i) => {
-            if (stringManipulation.isString(x) && stringManipulation.startsWithSlash(x)) {
-                karmaConfig.files[i] = x.substring(1);
-            } else if (
-                x.pattern &&
-                stringManipulation.isString(x.pattern) &&
-                stringManipulation.startsWithSlash(x.pattern)
-            ) {
-                karmaConfig.files[i].pattern = x.pattern.substring(1);
-            }
-        });
+        // ????: Why am I removing leading slashes again?
+        // karmaConfig.files.forEach((x, i) => {
+        //     if (stringManipulation.isString(x) && stringManipulation.startsWithSlash(x)) {
+        //         karmaConfig.files[i] = x.substring(1);
+        //     } else if (
+        //         x.pattern &&
+        //         stringManipulation.isString(x.pattern) &&
+        //         stringManipulation.startsWithSlash(x.pattern)
+        //     ) {
+        //         karmaConfig.files[i].pattern = x.pattern.substring(1);
+        //     }
+        // });
 
-        var processorKeys = Object.keys(karmaConfig.preprocessors);
-        processorKeys.forEach((key) => {
-            if (stringManipulation.startsWithSlash(key)) {
-                karmaConfig.preprocessors[key.substring(1)] = ["coverage"];
-                delete karmaConfig.preprocessors[key];
-            }
-        });
+        // var processorKeys = Object.keys(karmaConfig.preprocessors);
+        // processorKeys.forEach((key) => {
+        //     if (stringManipulation.startsWithSlash(key)) {
+        //         karmaConfig.preprocessors[key.substring(1)] = ["coverage"];
+        //         delete karmaConfig.preprocessors[key];
+        //     }
+        // });
         // logit(karmaConfig);
 
         karma.config

--- a/services/wrappedKarma.js
+++ b/services/wrappedKarma.js
@@ -5,7 +5,6 @@
 const karma = require("karma");
 
 const karmaConfigTools = require("./karmaConfigTools");
-const stringManipulation = require("../helpers/stringManipulation");
 const utils = require("../helpers/utils");
 
 let karmaRunIds = [];
@@ -19,28 +18,6 @@ function startKarma(karmaRunId, overrides) {
             overrides
         );
         var karmaConfig = karmaConfigTools.createKarmaConfig(overrides);
-
-        // ????: Why am I removing leading slashes again?
-        // karmaConfig.files.forEach((x, i) => {
-        //     if (stringManipulation.isString(x) && stringManipulation.startsWithSlash(x)) {
-        //         karmaConfig.files[i] = x.substring(1);
-        //     } else if (
-        //         x.pattern &&
-        //         stringManipulation.isString(x.pattern) &&
-        //         stringManipulation.startsWithSlash(x.pattern)
-        //     ) {
-        //         karmaConfig.files[i].pattern = x.pattern.substring(1);
-        //     }
-        // });
-
-        // var processorKeys = Object.keys(karmaConfig.preprocessors);
-        // processorKeys.forEach((key) => {
-        //     if (stringManipulation.startsWithSlash(key)) {
-        //         karmaConfig.preprocessors[key.substring(1)] = ["coverage"];
-        //         delete karmaConfig.preprocessors[key];
-        //     }
-        // });
-        // logit(karmaConfig);
 
         karma.config
             .parseConfig(


### PR DESCRIPTION
macOS was removing slashes and then adding the root folder path to the path that was previously a full path -- but didn't look like it any more because of the removed slash.

It was working on Windows, I believe, because the full paths included drive letters, naturally enough.

Seems to be working on macOS.

Also removed the debugLog output from the console for now.