### PR TITLE
CodeCoverage quick hack

### DIFF
--- a/helpers/selectorUtilities.js
+++ b/helpers/selectorUtilities.js
@@ -7,8 +7,10 @@ const utils = require("./utils");
 // B. minimatch won't match ../ equivalents in "collapsed" paths.
 // > . and .. are maintained in the pattern, meaning that they must also appear in the same position in
 // > the test path string. Eg, a pattern like a/*/../c will match the string a/b/../c but not the string a/c.
-//      Treatise on glob "standards":
+//      Further reading:
 //          https://github.com/isaacs/minimatch/issues/30#issuecomment-1040599045
+//      Treatise on glob "standards":
+//          https://github.com/isaacs/minimatch/issues/172#issuecomment-1359582179
 //      (It looked like optimizationLevel:2 would change that, but it doesn't.)
 //      https://github.com/isaacs/minimatch#optimizationlevel
 //      (Appears that's b/c you're using v5, not v7+)

--- a/index.js
+++ b/index.js
@@ -213,9 +213,9 @@ if (require.main === module) {
                     ? actionTypes.RUN_ALL_CHUTZPAHS
                     : myArgs.indexOf("/walkAllRunOne") > -1
                     ? actionTypes.WALK_ALL_RUN_ONE
-                    : myArgs.indexOf("/runOne") > -1
-                    ? actionTypes.RUN_ONE_IN_KARMA
-                    : actionTypes.PRINT_USAGE;
+                    : myArgs.indexOf("/version") > -1
+                    ? actionTypes.PRINT_USAGE
+                    : actionTypes.RUN_ONE_IN_KARMA;
 
             utils.debugLog(command);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "khutzpa",
-    "version": "0.0.1-alpha.9",
+    "version": "0.0.1-alpha.10",
     "description": "Node powered, cross-platform, drop-in replacement for Chutzpah.exe",
     "main": "index.js",
     "bin": "index.js",

--- a/services/chutzpahReader.js
+++ b/services/chutzpahReader.js
@@ -168,10 +168,10 @@ function handleAggressiveStar(configInfo) {
     });
 
     // now do the same for coverage includes and excludes.
-    configInfo.CodeCoverageIncludes = configInfo.CodeCoverageIncludes.concat(
+    configInfo.CodeCoverageIncludes = (configInfo.CodeCoverageIncludes || []).concat(
         _aggressiveStarEngine(configInfo.CodeCoverageIncludes, "coverageIncludes")
     );
-    configInfo.CodeCoverageIgnores = configInfo.CodeCoverageIgnores.concat(
+    configInfo.CodeCoverageIgnores = (configInfo.CodeCoverageIgnores || []).concat(
         _aggressiveStarEngine(configInfo.CodeCoverageIgnores, "coverageIgnores")
     );
 }
@@ -347,7 +347,7 @@ function getConfigInfo(originalTestPath) {
 
     configFilePath = nodePath.resolve(configFilePath);
 
-    utils.debugLog("Reading Chutzpah config: " + configFilePath);
+    console.log("Reading Chutzpah config: " + configFilePath);
     var jsonFilePath = nodePath.normalize(configFilePath);
     var jsonFileParent = nodePath.dirname(jsonFilePath);
 

--- a/services/chutzpahReader.js
+++ b/services/chutzpahReader.js
@@ -174,6 +174,9 @@ function handleAggressiveStar(configInfo) {
     configInfo.CodeCoverageIgnores = (configInfo.CodeCoverageIgnores || []).concat(
         _aggressiveStarEngine(configInfo.CodeCoverageIgnores, "coverageIgnores")
     );
+    configInfo.CodeCoverageExcludes = (configInfo.CodeCoverageExcludes || []).concat(
+        _aggressiveStarEngine(configInfo.CodeCoverageExcludes, "coverageExcludes")
+    );
 }
 
 // GET ALL REFERENCE FILES (files needed to run stuff)
@@ -232,10 +235,20 @@ function getCoverageFiles(chutzpahConfigObj, allRefFilePaths, jsonFileParent) {
     // the easiest way to reuse our current selector logic is to take
     // CodeCoverageIncludes & CodeCoverageExcludes and make a selector
     // out of them.
+
+    // This is a very naive implementation for CodeCoverageIgnores vs.
+    // CodeCoverageExcludes. For now, it simply ensures we do *something* with both
+    // excludes and ignores for code coverage for some level of backwards
+    // compatibility.  In this implementation, CodeCoverageIgnores and
+    // CodeCoverageExcludes are treated the same.
+    // That is, downstream we currently ONLY LOOK AT IGNORES.
+    // https://github.com/mmanela/chutzpah/wiki/Chutzpah.json-Settings-File
     var fakeSelector = {
         Path: jsonFileParent,
         Includes: chutzpahConfigObj.CodeCoverageIncludes,
-        Excludes: chutzpahConfigObj.CodeCoverageIgnores,
+        Excludes: chutzpahConfigObj.CodeCoverageIgnores.concat(
+            chutzpahConfigObj.CodeCoverageExcludes
+        ),
     };
 
     // I think we're really only interested in ref files, though, so we'll


### PR DESCRIPTION
* Mainly adding the naive CodeCoverageIgnores vs Excludes fix.
* Also removing requirement to specify a command option to run tests (used to show usage, now `/runOne` is the default)
* A few comment edits.