### PR TITLE
Swap to scoped karma-coverage fix. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "khutzpa",
-    "version": "0.0.1-alpha.10",
+    "version": "0.0.1-alpha.11",
     "description": "Node powered, cross-platform, drop-in replacement for Chutzpah.exe",
     "main": "index.js",
     "bin": "index.js",
@@ -30,7 +30,7 @@
         "express": "^4.18.1",
         "karma": "^6.4.0",
         "karma-chrome-launcher": "^3.1.1",
-        "karma-coverage": "^2.2.0",
+        "@rufwork/karma-coverage": "2.0.2-alpha.1",
         "karma-jasmine": "^5.1.0",
         "karma-mocha-reporter": "^2.2.5",
         "minimatch": "^5.1.0",

--- a/services/karmaConfigTools.js
+++ b/services/karmaConfigTools.js
@@ -88,6 +88,17 @@ const createKarmaConfig = function (overrides) {
     utils.debugLog("x:logLevel,5", overrides);
 
     var baseConfig = {
+        // For the scoped npm package karma-coverage workaround
+        // https://karma-runner.github.io/2.0/config/plugins.html
+        // Note that it doesn't *also* load up the karma-* sibling npms
+        // the way it did before. You are now on the hook for all of them.
+        plugins: [
+            "@rufwork/karma-coverage",
+            "karma-chrome-launcher",
+            "karma-jasmine",
+            "karma-mocha-reporter",
+        ],
+
         // frameworks to use
         // available frameworks: https://www.npmjs.com/search?q=keywords:karma-adapter
         frameworks: ["jasmine"],

--- a/tests/fakeSite/Chutzpah.json
+++ b/tests/fakeSite/Chutzpah.json
@@ -3,7 +3,7 @@
         {
             "Path": "/source/",
             "Includes": "**/*.js",
-            "Excludes": ["**/add2.misplaced_in_source.test.js", "**/coverage/**"]
+            "Excludes": ["**/coverage/**"]
         }
     ],
     "Tests": [


### PR DESCRIPTION
Unfortunately karma-coverage doesn't (always?) return a return value indicating if the coverage run was successful or not. That means khutzpa's return value won't, for instance, stop a build script when the coverage check fails as `echo %ERRORLEVEL%` (cmd) or `echo $LastExitCode (pwsh)` always return 0 indicating success.

Here's an issue on karma-coverage from last December:
* [Exit code 0 even if the coverage fails when reporter's file is missing #485](https://github.com/karma-runner/karma-coverage/issues/485)

Luckily there's also a pretty straightforward PR fixing it
* [fix: exit code when reporter file is not provided #486](https://github.com/karma-runner/karma-coverage/pull/486)

Unfortunately, though the PR was quickly reviewed & approved by a past committer to karma-coverage, nobody has merged it.

As a workaround, a scoped version has been set up here with the fix applied:  
https://www.npmjs.com/package/@rufwork/karma-coverage

Unfortunately scoped packages don't follow karma's convention for auto-loading plugins.

https://karma-runner.github.io/2.0/config/plugins.html
> By default, Karma loads all sibling NPM modules which have a name starting with `karma-*`.

That means we have to list *all* of our plugins by name in the karma config.

But with those two changes, we seem to be in business.