### PR TITLE
Allow http reference paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,9 @@ function cmdCallHandler(startingFilePath, expressPort, actionType, args) {
 
             fnAction = function (configInfo) {
                 var allFiles = configInfo.allRefFilePaths.concat(configInfo.specFiles);
-                var root = findTheRoot(allFiles);
+                var root = findTheRoot(
+                    allFiles.filter((x) => !x.toLowerCase().startsWith("http"))
+                );
 
                 return specRunner.createSpecHtml(configInfo, false, root).then(
                     (results) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "khutzpa",
-    "version": "0.0.1-alpha.11",
+    "version": "0.0.1-alpha.12",
     "description": "Node powered, cross-platform, drop-in replacement for Chutzpah.exe",
     "main": "index.js",
     "bin": "index.js",

--- a/services/chutzpahReader.js
+++ b/services/chutzpahReader.js
@@ -37,6 +37,13 @@ function handleChutzpahSelector(selector, chutzpahJsonFileParent, type, nth) {
         jsonFileParent: chutzpahJsonFileParent,
     });
 
+    // Tacked on logic to handle paths hosted via http.
+    if (selector.Path.toLowerCase().startsWith("http")) {
+        // Currently no QA for web paths -- invalid url, you're toast.
+        // TODO: Support gopher:// ?
+        return [selector.Path];
+    }
+
     if (!selector.Path) {
         selector.Path = chutzpahJsonFileParent;
     }

--- a/services/fileSystemService.js
+++ b/services/fileSystemService.js
@@ -63,7 +63,7 @@ function filterNonexistentPaths(fullPaths, type) {
     type = type || "References";
 
     return fullPaths.filter((fullPath) => {
-        if (!fs.existsSync(fullPath)) {
+        if (!fullPath.toLowerCase().startsWith("http") && !fs.existsSync(fullPath)) {
             console.warn(
                 `#### File listed in Chutzpah config's ${type} does not exist!
 ${fullPath}`

--- a/services/runJasmineSpecs.js
+++ b/services/runJasmineSpecs.js
@@ -77,11 +77,19 @@ Note: There is currently no way to override this check.
 
 TODO: Allow overriding this check.`);
         } else {
-            // This is kinda hacky. If there are more extensions we're worried about, refactor
-            // a bit.
-            forRunner += (
-                filePath.endsWith(".css") ? stylesheetTemplate : scriptTemplate
-            ).replace("1", nodePath.relative(root, filePath));
+            var templateNow = filePath.toLowerCase().endsWith(".css")
+                ? stylesheetTemplate
+                : scriptTemplate;
+
+            forRunner +=
+                // This is kinda hacky. If there are more extensions we're worried about, refactor.
+                templateNow.replace(
+                    "1",
+                    // This is tacked on: If it's http, don't append a relative root.
+                    filePath.toLowerCase().startsWith("http")
+                        ? filePath
+                        : nodePath.relative(root, filePath)
+                );
         }
     }
 


### PR DESCRIPTION
Right now khutzpa mangles References (and tests, I suppose) that start with `http`.

Chutzpah supported them, so I guess we ought to too.