### PR TITLE
Alert & error out when path parameter is a single file, but that file isn't a test

### DIFF
--- a/helpers/utils.js
+++ b/helpers/utils.js
@@ -61,6 +61,10 @@ function alwaysLog() {
     debugLog(`${settingsCue}alwaysLog`, ...arguments);
 }
 
+function log50() {
+    debugLog(`${settingsCue}loglevel,50`, ...arguments);
+}
+
 function debugLog() {
     var args = [].slice.call(arguments);
     // eslint-disable-next-line
@@ -127,6 +131,7 @@ function mcDebugger() {
 
 module.exports = {
     debugLog,
+    log50,
     alwaysLog,
     mcDebugger,
     isParseable,

--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ var actionTypes = {
     FIND_ALL_CHUTZPAHS: 4,
     WALK_ALL_RUN_ONE: 5,
     PRINT_USAGE: 6,
-    RUN_ONE_IN_KARMA: 7,
+    RUN_ONE_IN_KARMA: 7, // the default
 };
 
 if (require.main === module) {
@@ -231,9 +231,9 @@ if (require.main === module) {
                     Array.isArray(resultsIfAny) &&
                     !resultsIfAny.every((x) => x === undefined)
                 ) {
-                    console.log("::RESULTS::");
+                    console.log("\n\n::RESULTS::");
                     console.log(resultsIfAny);
-                    console.log("::eoRESULTS::");
+                    console.log("::eoRESULTS::\n\n");
 
                     const firstError = resultsIfAny.find((x) => x && x !== 0);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "khutzpa",
-    "version": "0.0.1-alpha.12",
+    "version": "0.0.1-alpha.13",
     "description": "Node powered, cross-platform, drop-in replacement for Chutzpah.exe",
     "main": "index.js",
     "bin": "index.js",

--- a/services/chutzpahReader.js
+++ b/services/chutzpahReader.js
@@ -37,15 +37,15 @@ function handleChutzpahSelector(selector, chutzpahJsonFileParent, type, nth) {
         jsonFileParent: chutzpahJsonFileParent,
     });
 
+    if (!selector.Path) {
+        selector.Path = chutzpahJsonFileParent;
+    }
+
     // Tacked on logic to handle paths hosted via http.
     if (selector.Path.toLowerCase().startsWith("http")) {
         // Currently no QA for web paths -- invalid url, you're toast.
         // TODO: Support gopher:// ?
         return [selector.Path];
-    }
-
-    if (!selector.Path) {
-        selector.Path = chutzpahJsonFileParent;
     }
 
     // I don't know that we *have* to ensure the files exist, but to use fs.existsSync,
@@ -434,3 +434,4 @@ module.exports = {
     getConfigInfo,
     findChutzpahJson, // okay, this was made public only for testing. That's bad.
 };
+

--- a/services/wrappedKarma.js
+++ b/services/wrappedKarma.js
@@ -61,8 +61,8 @@ function startKarma(karmaRunId, overrides) {
 }
 
 function runWrappedKarma(configInfo, karmaRunId) {
-    // The config object gives back a collection of all refs (not tests)
-    // in allRefFilePaths and the tests in specFiles.
+    // The config object gives back a collection of all refs (ie, required
+    // files that arne't tests) in allRefFilePaths and the tests in specFiles.
     // karma's files property wants everything... I think...
     // So first let's put the two together.
     var allFiles = configInfo.allRefFilePaths.concat(configInfo.specFiles);
@@ -90,8 +90,13 @@ function runWrappedKarma(configInfo, karmaRunId) {
         // "**/!(*test).js": ["coverage"],
         preprocessors: preprocessObj,
     };
-    utils.debugLog("config overrides for karma:", overrides);
 
+    // if we only have one test file, no reason to do any coverage.
+    if (configInfo.singleTestFile) {
+        overrides.reporters = ["mocha"];
+    }
+
+    utils.debugLog("config overrides for karma:", overrides);
     return startKarma(karmaRunId, overrides);
 }
 


### PR DESCRIPTION
That's really it. One bug fix for when a selector's Path is empty and also skips displaying the `Unknown` style results when running coverage with a single file.