### PR TITLE
Swap back f/ scoped karma-coverage to the real karma-coverage now that it's bugfixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ package-lock.json
 coverage
 tests/testChutzpahReader.js
 log.txt
+testMe.bat

--- a/index.js
+++ b/index.js
@@ -36,6 +36,11 @@ khutzpa /path/to/root/directory /{command}
     /usage
 
 `);
+
+    // If you're showing usage you may have had a bogus command.
+    // Chances are, if you care about return values, you don't want
+    // usage shown.
+    process.exit(846); // "bad"
 }
 
 function cmdCallHandler(startingFilePath, expressPort, actionType, args) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "khutzpa",
-    "version": "0.0.1-alpha.13",
+    "version": "0.0.1-alpha.14",
     "description": "Node powered, cross-platform, drop-in replacement for Chutzpah.exe",
     "main": "index.js",
     "bin": "index.js",
@@ -30,7 +30,7 @@
         "express": "^4.18.1",
         "karma": "^6.4.0",
         "karma-chrome-launcher": "^3.1.1",
-        "@rufwork/karma-coverage": "2.0.2-alpha.1",
+        "karma-coverage": "^2.2.1",
         "karma-jasmine": "^5.1.0",
         "karma-mocha-reporter": "^2.2.5",
         "minimatch": "^5.1.0",

--- a/services/karmaConfigTools.js
+++ b/services/karmaConfigTools.js
@@ -88,16 +88,16 @@ const createKarmaConfig = function (overrides) {
     utils.debugLog("x:logLevel,5", overrides);
 
     var baseConfig = {
-        // For the scoped npm package karma-coverage workaround
+        // Remember that if any of your karma-* plugins are scoped or otherwise
+        // don't start with "karma-", you'll have to declare ALL of them.
         // https://karma-runner.github.io/2.0/config/plugins.html
-        // Note that it doesn't *also* load up the karma-* sibling npms
-        // the way it did before. You are now on the hook for all of them.
-        plugins: [
-            "@rufwork/karma-coverage",
-            "karma-chrome-launcher",
-            "karma-jasmine",
-            "karma-mocha-reporter",
-        ],
+        // "By default, Karma loads all sibling NPM modules which have a name starting with karma-*...."
+        // plugins: [
+        //     "karma-coverage",
+        //     "karma-chrome-launcher",
+        //     "karma-jasmine",
+        //     "karma-mocha-reporter",
+        // ],
 
         // frameworks to use
         // available frameworks: https://www.npmjs.com/search?q=keywords:karma-adapter

--- a/services/karmaConfigTools.js
+++ b/services/karmaConfigTools.js
@@ -45,7 +45,7 @@ const overridesForCoverage = {
     // possible values: 'dots', 'progress'
     // available reporters: https://www.npmjs.com/search?q=keywords:karma-reporter
     // coverage reporter generates the coverage
-    reporters: ["coverage"],
+    reporters: ["coverage", "mocha"],
 
     // optionally, configure the reporter
     // https://github.com/karma-runner/karma-coverage/blob/HEAD/docs/configuration.md

--- a/services/wrappedKarma.js
+++ b/services/wrappedKarma.js
@@ -94,6 +94,27 @@ function runWrappedKarma(configInfo, karmaRunId) {
     // if we only have one test file, no reason to do any coverage.
     if (configInfo.singleTestFile) {
         overrides.reporters = ["mocha"];
+    } else {
+        var codeCoverageSuccessPercentage = parseInt(
+            configInfo.codeCoverageSuccessPercentage,
+            10
+        );
+
+        if (codeCoverageSuccessPercentage) {
+            // https://github.com/karma-runner/karma-coverage/blob/master/docs/configuration.md#check
+            overrides.coverageReporter = {
+                reporters: [{ type: "text-summary" }],
+                check: {
+                    emitWarning: false,
+                    global: {
+                        statements: codeCoverageSuccessPercentage,
+                        branches: codeCoverageSuccessPercentage,
+                        functions: codeCoverageSuccessPercentage,
+                        lines: codeCoverageSuccessPercentage,
+                    },
+                },
+            };
+        }
     }
 
     utils.debugLog("config overrides for karma:", overrides);


### PR DESCRIPTION
Undo [previous changes to use scoped `karma-coverage`](https://www.npmjs.com/package/@rufwork/karma-coverage) and point to [the new, bugfixed, actual `karma-coverage`](https://github.com/karma-runner/karma-coverage/compare/v2.2.0...v2.2.1) v. 2.2.1 or greater.