### PR TITLE
Move Jasmine filter from spec runner to all ref/test file spiders.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "khutzpa",
-    "version": "0.0.1-alpha.15",
+    "version": "0.0.1-alpha.16",
     "description": "Node powered, cross-platform, drop-in replacement for Chutzpah.exe",
     "main": "index.js",
     "bin": {

--- a/services/chutzpahReader.js
+++ b/services/chutzpahReader.js
@@ -42,7 +42,7 @@ function filterJasmine(collection) {
             jasmineHits.push(x);
         }
 
-        // Keep if NOT jasmine.
+        // Keep if does NOT contain jasmine (ie, most file).
         return !hit;
     });
 
@@ -53,7 +53,7 @@ ${jasmineHits.join("\n")}
 
 We're ignoring any files that contains the characters "jasmine" and ends in ".js".
 khutzpa provides its own version of jasmine.  Referencing another version of jasmine can
-break tests. Currently skipping this file.
+break tests. Currently skipping these file. (They may be listed multiple times.)
 
 Note: There is currently no way to override this check.
 TODO: Allow overriding this check.`);

--- a/services/chutzpahReader.js
+++ b/services/chutzpahReader.js
@@ -31,6 +31,37 @@ function mergeDedupeAndStandardizePathSeparator(parentCollection, newFiles) {
     return parentCollection.concat(filesForSelectorDeduped);
 }
 
+// TODO: This is effectively but entirely too aggressive.
+function filterJasmine(collection) {
+    var jasmineHits = [];
+    var filteredCollection = collection.filter((x) => {
+        var hit =
+            x.toLowerCase().indexOf("jasmine") > -1 && x.toLowerCase().endsWith(".js");
+
+        if (hit) {
+            jasmineHits.push(x);
+        }
+
+        // Keep if NOT jasmine.
+        return !hit;
+    });
+
+    if (jasmineHits.length) {
+        console.warn(`
+!!!!!! JASMINE POTENTIALLY FOUND !!!!!!
+${jasmineHits.join("\n")}
+
+We're ignoring any files that contains the characters "jasmine" and ends in ".js".
+khutzpa provides its own version of jasmine.  Referencing another version of jasmine can
+break tests. Currently skipping this file.
+
+Note: There is currently no way to override this check.
+TODO: Allow overriding this check.`);
+    }
+
+    return filteredCollection;
+}
+
 function handleChutzpahSelector(selector, chutzpahJsonFileParent, type, nth) {
     utils.debugLog({
         title: "handleChutzpahSelector",
@@ -70,7 +101,10 @@ function handleChutzpahSelector(selector, chutzpahJsonFileParent, type, nth) {
             selectorMatchesFullPaths =
                 fileSystemService.getAllFilePaths(selectorFullPath);
 
-            // 2. Run the file paths against include & exclude globs from config.
+            // 2. For now, over-aggressively remove jasmine files.
+            selectorMatchesFullPaths = filterJasmine(selectorMatchesFullPaths);
+
+            // 3. Run the file paths against include & exclude globs from config.
             utils.debugLog(`all files for ${nth}th ${type} selector before filtering:
     ${selectorFullPath}
 ${JSON.stringify(selectorMatchesFullPaths, null, "  ")}
@@ -93,9 +127,9 @@ ${JSON.stringify(selectorMatchesFullPaths, null, "  ")}
 
 `);
         } else {
-            selectorMatchesFullPaths = [
+            selectorMatchesFullPaths = filterJasmine([
                 nodePath.join(chutzpahJsonFileParent, selector.Path),
-            ];
+            ]);
         }
 
         return selectorMatchesFullPaths;

--- a/services/karmaConfigTools.js
+++ b/services/karmaConfigTools.js
@@ -102,6 +102,10 @@ const createKarmaConfig = function (overrides) {
         //     "karma-trx-reporter",
         // ],
 
+        // jasmine: {
+        //     random: false,
+        // },
+
         // frameworks to use
         // available frameworks: https://www.npmjs.com/search?q=keywords:karma-adapter
         frameworks: ["jasmine"],

--- a/services/runJasmineSpecs.js
+++ b/services/runJasmineSpecs.js
@@ -68,29 +68,19 @@ function configInfoToTestRunnerScript(configInfo, root) {
     var forRunner = "<!-- include source files here -->\n";
 
     function insertToTemplate(filePath) {
-        if (filePath.indexOf("jasmine") > -1 && filePath.endsWith(".js")) {
-            console.warn(`
-!!!!!! ${filePath}
-contains the characters "jasmine". khutzpa provides its own version of jasmine.
-Referencing another version of jasmine can break tests. Currently skipping this file.
-Note: There is currently no way to override this check.
+        var templateNow = filePath.toLowerCase().endsWith(".css")
+            ? stylesheetTemplate
+            : scriptTemplate;
 
-TODO: Allow overriding this check.`);
-        } else {
-            var templateNow = filePath.toLowerCase().endsWith(".css")
-                ? stylesheetTemplate
-                : scriptTemplate;
-
-            forRunner +=
-                // This is kinda hacky. If there are more extensions we're worried about, refactor.
-                templateNow.replace(
-                    "1",
-                    // This is tacked on: If it's http, don't append a relative root.
-                    filePath.toLowerCase().startsWith("http")
-                        ? filePath
-                        : nodePath.relative(root, filePath)
-                );
-        }
+        forRunner +=
+            // This is kinda hacky. If there are more extensions we're worried about, refactor.
+            templateNow.replace(
+                "1",
+                // This is tacked on: If it's http, don't append a relative root.
+                filePath.toLowerCase().startsWith("http")
+                    ? filePath
+                    : nodePath.relative(root, filePath)
+            );
     }
 
     configInfo.allRefFilePaths.forEach(insertToTemplate);


### PR DESCRIPTION
[Move Jasmine filter from spec runner to all ref/test file spiders.](https://github.com/ruffin--/khutzpa/commit/f3c1996017dc8fb7d01bd852ffc60864805537b8).

Also ensure that single file selectors are also checked for jasmine so stuff like 

```
    "References": [
        { "Path": "/Scripts/jasmine.js" },
// ...
```

doesn't cause trouble.